### PR TITLE
Check for visual element when determining popup position

### DIFF
--- a/SlideOverKit/SlidePopupView.cs
+++ b/SlideOverKit/SlidePopupView.cs
@@ -97,8 +97,10 @@ namespace SlideOverKit
                         LeftMargin -= (parent as ScrollView).ScrollX;
                         TopMargin -= (parent as ScrollView).ScrollY;
                     }
-                    LeftMargin += (parent as VisualElement).X;
-                    TopMargin += (parent as VisualElement).Y;
+                    if (parent is VisualElement) {
+                        LeftMargin += (parent as VisualElement).X;
+                        TopMargin += (parent as VisualElement).Y;
+                    }
                     parent = parent.Parent;
                 }
             }


### PR DESCRIPTION
When the popup with targetcontrol checks parent tree for position, it doesn't check if parent is VisualElement, so in the case of a ViewCell for example an exception gets thrown.